### PR TITLE
Fix parsing as local date in cljs

### DIFF
--- a/src/luminus_transit/time.cljc
+++ b/src/luminus_transit/time.cljc
@@ -35,9 +35,9 @@
 #?(:cljs
    (def time-deserialization-handlers
      {:handlers
-      {"LocalTime"     (transit/read-handler #(tf/parse iso-local-time %))
-       "LocalDate"     (transit/read-handler #(tf/parse iso-local-date %))
-       "LocalDateTime" (transit/read-handler #(tf/parse iso-local-date-time %))
+      {"LocalTime"     (transit/read-handler #(tf/parse-local iso-local-time %))
+       "LocalDate"     (transit/read-handler #(tf/parse-local-date iso-local-date %))
+       "LocalDateTime" (transit/read-handler #(tf/parse-local iso-local-date-time %))
        "ZonedDateTime" (transit/read-handler #(tf/parse iso-zoned-date-time %))}}))
 
 #?(:cljs


### PR DESCRIPTION
This PR fixes an issue where LocalDate are parsed as DateTime, with 00:00 as time. Also I updated parsing logic to use local time if indicated.