### PR TITLE
Add type hint to avoid reflection warning

### DIFF
--- a/src/luminus_transit/time.cljc
+++ b/src/luminus_transit/time.cljc
@@ -66,13 +66,13 @@
      {:handlers
       {java.time.LocalTime     (transit/write-handler
                                  (constantly "LocalTime")
-                                 #(.format % iso-local-time))
+                                 #(.format ^LocalTime % iso-local-time))
        java.time.LocalDate     (transit/write-handler
                                  (constantly "LocalDate")
-                                 #(.format % iso-local-date))
+                                 #(.format ^LocalDate % iso-local-date))
        java.time.LocalDateTime (transit/write-handler
                                  (constantly "LocalDateTime")
-                                 #(.format % iso-local-date-time))
+                                 #(.format ^LocalDateTime % iso-local-date-time))
        java.time.ZonedDateTime (transit/write-handler
                                  (constantly "ZonedDateTime")
-                                 #(.format % iso-zoned-date-time))}}))
+                                 #(.format ^ZonedDateTime % iso-zoned-date-time))}}))


### PR DESCRIPTION
Fix

Reflection warning, luminus_transit/time.cljc:69:35 - call to method format can't be resolved (target class is unknown).
Reflection warning, luminus_transit/time.cljc:72:35 - call to method format can't be resolved (target class is unknown).
Reflection warning, luminus_transit/time.cljc:75:35 - call to method format can't be resolved (target class is unknown).
Reflection warning, luminus_transit/time.cljc:78:35 - call to method format can't be resolved (target class is unknown).